### PR TITLE
Devolve objeto vazio em caso de erro

### DIFF
--- a/Gateway/Services/ViaCep.php
+++ b/Gateway/Services/ViaCep.php
@@ -23,6 +23,10 @@ class ViaCep extends AbstractZipCodeService
         }
 
         if ($response && $response->getStatusCode() == 200) {
+            $isError = isset($responseBody['erro']) && $responseBody['erro'] === true;
+            if ($isError) {
+                return $zipObject;
+            }
             $responseBody = json_decode($response->getBody(), true);
             $zipObject->setStreet($responseBody['logradouro'] ?? null);
             $zipObject->setRegion($responseBody['uf'] ?? null);


### PR DESCRIPTION
Quando o viaCep devolve erro=true temos erros de variáveis não definidas (Fixes #1 ).
Este PR resolve o problema.