### PR TITLE
Fix unhandled error when cep is not found

### DIFF
--- a/Gateway/Services/ViaCep.php
+++ b/Gateway/Services/ViaCep.php
@@ -23,19 +23,22 @@ class ViaCep extends AbstractZipCodeService
         }
 
         if ($response && $response->getStatusCode() == 200) {
+            $responseBody = json_decode($response->getBody(), true);
             $isError = isset($responseBody['erro']) && $responseBody['erro'] === true;
+
             if ($isError) {
                 return $zipObject;
             }
-            $responseBody = json_decode($response->getBody(), true);
+
             $zipObject->setStreet($responseBody['logradouro'] ?? null);
             $zipObject->setRegion($responseBody['uf'] ?? null);
-            $zipObject->setRegionId($this->config->getRegionId($responseBody['uf'], 'BR') ?? null);
+            $zipObject->setRegionId($this->config->getRegionId($responseBody['uf'] ?? null, 'BR'));
             $zipObject->setNeighborhood($responseBody['bairro'] ?? null);
             $zipObject->setCity($responseBody['localidade'] ?? null);
             $zipObject->setAdditionalInfo($responseBody['complemento'] ?? null);
             $zipObject->setCode($responseBody['ibge'] ?? null);
             $zipObject->setIsValid($this->validate($zipObject));
+
             return $zipObject;
         }
         return $zipObject;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Módulo criado para utilização de serviços de consulta de CEP, já contendo d
 
 #### Instalar via Composer (recomendado)
 ```
-composer require feeh27/brazilzipcode
+composer require magedev/brazilzipcode
 php bin/magento module:enable MageDev_BrazilZipCode
 php bin/magento setup:upgrade
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Módulo criado para utilização de serviços de consulta de CEP, já contendo d
 
 #### Instalar via Composer (recomendado)
 ```
-composer require magedev/brazilzipcode
+composer require feeh27/brazilzipcode
 php bin/magento module:enable MageDev_BrazilZipCode
 php bin/magento setup:upgrade
 ```

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
         "psr-4": {
             "MageDev\\BrazilZipCode\\": ""
         }
+    },
+    "require": {
+        "ext-json": "*"
     }
 }


### PR DESCRIPTION
O Magento estava retornando erro 500 pois o Gateway ViaCep não estava tratando um erro corretamente, fiz a correção e disponibilizo aqui para que todos possam utilizar.