### PR TITLE
Alterações para adequação ao PHP 8.0 (Magento 2.4.3 >)

### DIFF
--- a/Gateway/Services/CacheService.php
+++ b/Gateway/Services/CacheService.php
@@ -54,7 +54,7 @@ class CacheService implements ZipCodeServiceInterface
     public function getCacheData()
     {
         $cacheData = $this->cacheType->load(ApiSearchType::CACHE_TAG);
-        return unserialize($cacheData);
+        return $cacheData ? unserialize($cacheData) : [];
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -101,7 +101,10 @@ class Config
      */
     public function updateSystemServicesConfig($data)
     {
-        $configServices = json_decode($this->getSortOrder(), true);
+        if($this->getSortOrder())
+            $configServices = json_decode($this->getSortOrder(), true);
+        else
+            $configServices = null;
 
         if (!is_array($configServices)) {
             $configServices = [];


### PR DESCRIPTION
Realizei duas correções de problemas que enfrentei ao instalar o módulo no Magento 2.4.5 CE, com PHP 8.1.

Após as correções, o módulo funcionou como esperado.
As alterações devem ser totalmente retrocompatíveis com PHP 7.